### PR TITLE
Add livereload options to grunt-contrib-watch.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -107,6 +107,9 @@ module.exports = (grunt) ->
         atBegin: true
         interrupt: false
         spawn: false
+        # Set to `true` or set `livereload: 1337` to a port number to enable live reloading.
+        # Default and recommended port is 35729.
+        livereload: false
       js:
         files: ["<%= settings.base %><%= settings.theme %>assets/js/*.js"]
         tasks: ["jshint", "uglify:own"]


### PR DESCRIPTION
Issue #46: Add livereload option to watch tasks. Default the task is turned off.