### PR TITLE
Drupal CSS Coding Standards violation

### DIFF
--- a/scsslint.yml
+++ b/scsslint.yml
@@ -47,7 +47,7 @@ linters:
 
   HexNotation:
     enabled: true
-    style: uppercase # or 'lowercase'
+    style: lowercase # or 'uppercase'
 
   HexValidation:
     enabled: true


### PR DESCRIPTION
When hex values are used for colors, use lowercase and, if possible, the shorthand syntax, e.g. #aaa.